### PR TITLE
Remove duplicate of `libreadline-dev` in installation on ubuntu.

### DIFF
--- a/contents/install/ubuntu/index.rst
+++ b/contents/install/ubuntu/index.rst
@@ -29,7 +29,7 @@ Pythonのビルド
    $ sudo apt update
    $ sudo apt install build-essential libbz2-dev libdb-dev \
      libreadline-dev libffi-dev libgdbm-dev liblzma-dev \
-     libncursesw5-dev libreadline-dev libsqlite3-dev libssl-dev \
+     libncursesw5-dev libsqlite3-dev libssl-dev \
      zlib1g-dev uuid-dev tk-dev
 
 .. jinja::


### PR DESCRIPTION
`sudo apt install` 中に `libreadline-dev` が2回(2行目冒頭と修正箇所に)現れていますが，2回書く意味はなく，誤植であると思われます．