### PR TITLE
Fixed the description of the version of python that py.exe starts

### DIFF
--- a/contents/install/windows/py_launcher.rst
+++ b/contents/install/windows/py_launcher.rst
@@ -17,7 +17,7 @@ MacOS や Linux などの Unix系OSでは、``python`` コマンドや ``python3
    Type "help", "copyright", "credits" or "license" for more information.
    >>>
 
-``py.exe`` は、最後にインストールしたバージョンの Python を実行します。インストール済みの、他のバージョンの Python を実行する場合は、オプションで指定します。
+``py.exe`` は、インストールされている最新バージョンの Python を実行します。インストール済みの、他のバージョンの Python を実行する場合は、オプションで指定します。
 
 ``py -3.6`` と指定すると、Python 3.6を実行します。
 


### PR DESCRIPTION
Fixed the description of the version of python that py.exe starts.
The official document says:

> the latest version of Python you have installed is started

https://docs.python.org/3/using/windows.html#getting-started
https://docs.python.org/ja/3/using/windows.html#getting-started

Please check my PR 🙏 